### PR TITLE
fix(clean): fix doc-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ fpga-test:
 #
 # COMPILE DOCUMENTS
 #
+DOC ?= pb
 DOC_DIR=document/$(DOC)
 doc-build:
 	make -C $(DOC_DIR) $(DOC).pdf


### PR DESCRIPTION
- add missing `DOC` variable from Makefile
- fixes and close #8 